### PR TITLE
Implement connector metadata service

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,11 @@
 # API Watchtower
 
-Automated Notification System for API Change News 
+Automated Notification System for API Change News
+
+## Connector Metadata
+
+Connector details are fetched from the Celigo Integrator API. Set the
+environment variables `INTEGRATOR_API_BASE_URL` and `INTEGRATOR_API_KEY`
+before running the application. The `ConnectorMetadataService` class
+provides helper methods to retrieve all connectors or a specific
+connector by its id.

--- a/main.py
+++ b/main.py
@@ -1,6 +1,19 @@
-from services.orchestration_pipeline import make_pipeline
+from concurrent.futures import ThreadPoolExecutor
 
-if __name__ == "__main__":
-    connector_name = "Shopify"
+from services.orchestration_pipeline import make_pipeline
+from services.connectors_metadata_service import ConnectorMetadataService
+
+
+def run_pipeline(connector_name: str) -> None:
+    """Create and invoke the pipeline for a single connector."""
     pipeline = make_pipeline(connector_name)
     pipeline.invoke(None)
+
+if __name__ == "__main__":
+    service = ConnectorMetadataService()
+    connectors = service.get_all_connectors()
+    connector_names = [c.get("name") for c in connectors if c.get("name")]
+
+    # Run pipelines in parallel for all connectors
+    with ThreadPoolExecutor() as executor:
+        executor.map(run_pipeline, connector_names)

--- a/services/connectors_metadata_service.py
+++ b/services/connectors_metadata_service.py
@@ -1,0 +1,31 @@
+import os
+from typing import List, Dict, Any
+
+import requests
+
+
+class ConnectorMetadataService:
+    """Client for Celigo Integrator API connector metadata."""
+
+    def __init__(self) -> None:
+        self.base_url = os.getenv("INTEGRATOR_API_BASE_URL", "https://api.integrator.io/v1")
+        self.api_key = os.getenv("INTEGRATOR_API_KEY")
+        self.session = requests.Session()
+        if self.api_key:
+            self.session.headers.update({"Authorization": self.api_key})
+
+    def get_all_connectors(self) -> List[Dict[str, Any]]:
+        """Return metadata for all available connectors."""
+        url = f"{self.base_url}/httpconnectors"
+        resp = self.session.get(url)
+        resp.raise_for_status()
+        data = resp.json()
+        # Integrator API returns items under 'items' when paginated
+        return data.get("items", data)
+
+    def get_connector_by_id(self, connector_id: str) -> Dict[str, Any]:
+        """Return metadata for a connector by id."""
+        url = f"{self.base_url}/httpconnectors/{connector_id}"
+        resp = self.session.get(url, params={"returnEverything": "true"})
+        resp.raise_for_status()
+        return resp.json()


### PR DESCRIPTION
## Summary
- add service to fetch connector info from Integrator API
- run pipelines for all connectors in parallel
- document connector metadata configuration

## Testing
- `python -m py_compile $(git ls-files '*.py')`